### PR TITLE
Added explicit peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/xsm-ue/xsm-ajax-cache/issues"
   },
   "homepage": "https://github.com/xsm-ue/xsm-ajax-cache#readme",
+
+  "peerDependencies": {
+    "jquery": "*"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.0",


### PR DESCRIPTION
Currently, creating an app that depends on this package will fail immediately:

```
echo 'require("xsm-ajax-cache")' > app.js && node app.js
module.js:341
    throw err;
    ^

Error: Cannot find module 'jquery'
```

This adds jquery as an explicit dependency that the client must fulfill.